### PR TITLE
Don't show activity indicator when imageURL is nil

### DIFF
--- a/AsyncImageView/AsyncImageView.m
+++ b/AsyncImageView/AsyncImageView.m
@@ -664,7 +664,7 @@ NSString *const AsyncImageErrorKey = @"error";
 - (void)setImageURL:(NSURL *)imageURL
 {
     super.imageURL = imageURL;
-    if (_showActivityIndicator && !self.image)
+    if (_showActivityIndicator && !self.image && imageURL)
     {
         if (_activityView == nil)
         {


### PR DESCRIPTION
When nil is set as imageURL the activity indicator is shown and never
hidden. This pull request just doesn't show it in the first place.
