### PR TITLE
Handle Circumstances Where _connections is nil

### DIFF
--- a/AsyncImageView/AsyncImageView.m
+++ b/AsyncImageView/AsyncImageView.m
@@ -475,7 +475,7 @@ NSString *const AsyncImageErrorKey = @"error";
     for (int i = 0; i < [_connections count]; i++)
     {
         AsyncImageConnection *connection = [_connections objectAtIndex:i];
-        if (!connection.loading)
+        if (!connection.loading && _connections)
         {
             [_connections insertObject:connection atIndex:i];
             added = YES;


### PR DESCRIPTION
This update provides a simple sanity check to make sure that
_connections is not nil before trying to do stuff with it. Formerly the
library would cause an application crash if _connections was nil.
