### PR TITLE
 Handle Circumstances Where connection is nil Before Attempting Insert

### DIFF
--- a/AsyncImageView/AsyncImageView.m
+++ b/AsyncImageView/AsyncImageView.m
@@ -475,7 +475,7 @@ NSString *const AsyncImageErrorKey = @"error";
     for (int i = 0; i < [_connections count]; i++)
     {
         AsyncImageConnection *connection = [_connections objectAtIndex:i];
-        if (!connection.loading)
+        if (connection && !connection.loading)
         {
             [_connections insertObject:connection atIndex:i];
             added = YES;


### PR DESCRIPTION
This update provides a simple sanity check to make sure that
connection is not nil before trying to add it to the _connections array.
Formerly the library would cause an application crash if connection was
nil when attempting to insert it into the _connections array.
