### PR TITLE
UIImages are now created with a default retina scale

### DIFF
--- a/AsyncImageView/AsyncImageView.m
+++ b/AsyncImageView/AsyncImageView.m
@@ -44,6 +44,7 @@ NSString *const AsyncImageURLKey = @"URL";
 NSString *const AsyncImageCacheKey = @"cache";
 NSString *const AsyncImageErrorKey = @"error";
 
+CGFloat const AsyncImageRetinaScale = 2.0;
 
 @interface AsyncImageConnection : NSObject
 
@@ -178,7 +179,7 @@ NSString *const AsyncImageErrorKey = @"error";
 	{	
 		if (!_cancelled)
 		{
-            UIImage *image = [[UIImage alloc] initWithData:data];
+			UIImage *image = [UIImage imageWithData:data scale:AsyncImageRetinaScale];
 			if (image)
 			{
 				//add to cache (may be cached already but it doesn't matter)


### PR DESCRIPTION
As of iOS7, all devices sold are retina, so it makes sense to transition to loading all the images with the proper scale. This makes it possible when using UIImageViews to use the more interesting view modes like top-left, bottom-right, etc.

If you merge this directly, you'll break the code of people who depended on the old behavior. You might want to make it configurable with the default being 2.0.

[edit] It's not true about all ios7 devices being retina.  See comment by bastionhoyer below.
